### PR TITLE
Update functions.red

### DIFF
--- a/environment/functions.red
+++ b/environment/functions.red
@@ -689,7 +689,7 @@ split: func [
 	{Break a string series into pieces using the provided delimiters} 
 	series [any-string!] dlm [string! char!  bitset!]  /local s  num
 ] [
-	either string? dlm [num: length? dlm] [num 1]
+	either string? dlm [num: length? dlm] [num: 1]
 	collect [
 		parse series [
 			any [[copy s to dlm num skip (keep s)] | [copy s to end (keep s) skip] ]


### PR DESCRIPTION
This version of split seems to deliver more the way Rebols simple parse splits strings.
red>> split "1,2..,4" charset ",."
== ["1" "2" "" "" "4"]
red>> split "1,2..,4"  ","
== ["1" "2.." "4"]
